### PR TITLE
Adding Reusable empty state message

### DIFF
--- a/Application/To-Do.xcodeproj/project.pbxproj
+++ b/Application/To-Do.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		07F46C8525277C7E007DC6AC /* SortTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F46C8425277C7E007DC6AC /* SortTypes.swift */; };
+		4F953E502531C25E0027144C /* EmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F953E4F2531C25E0027144C /* EmptyState.swift */; };
 		5BBE559E2523A42700090F87 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBE559D2523A42700090F87 /* AppDelegate.swift */; };
 		5BBE55A02523A42700090F87 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBE559F2523A42700090F87 /* SceneDelegate.swift */; };
 		5BBE55A52523A42700090F87 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5BBE55A32523A42700090F87 /* Main.storyboard */; };
@@ -38,6 +39,7 @@
 
 /* Begin PBXFileReference section */
 		07F46C8425277C7E007DC6AC /* SortTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortTypes.swift; sourceTree = "<group>"; };
+		4F953E4F2531C25E0027144C /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
 		5BBE559A2523A42700090F87 /* To-Do.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "To-Do.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BBE559D2523A42700090F87 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5BBE559F2523A42700090F87 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 				5BBE55CA2524623900090F87 /* TextviewBorder.swift */,
 				FF2303B32529183700B88831 /* Alert.swift */,
 				E924B483252D53F3004FD116 /* CameraHelper.swift */,
+				4F953E4F2531C25E0027144C /* EmptyState.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -264,6 +267,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				07F46C8525277C7E007DC6AC /* SortTypes.swift in Sources */,
+				4F953E502531C25E0027144C /* EmptyState.swift in Sources */,
 				5BBE55B72523A90A00090F87 /* TodoViewController.swift in Sources */,
 				E924B484252D53F3004FD116 /* CameraHelper.swift in Sources */,
 				5BBE559E2523A42700090F87 /* AppDelegate.swift in Sources */,

--- a/Application/To-Do/Controller/ResultsTableController.swift
+++ b/Application/To-Do/Controller/ResultsTableController.swift
@@ -13,7 +13,37 @@ class ResultsTableController: UITableViewController {
     
     var todoList = [Task]()
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupEmptyState()
+    }
+    
+    fileprivate func setupEmptyState() {
+        
+        let image = UIImage(systemName: "magnifyingglass")!
+        let heading = "No tasks found :("
+        let subheading = """
+        The task you search is not found.
+        Create new one!
+        """
+        
+        let emptyView = EmptyState(image: image, heading: heading, subheading: subheading)
+        self.tableView.backgroundView = emptyView
+        self.tableView.setNeedsLayout()
+        self.tableView.layoutIfNeeded()
+    }
+    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        
+        if todoList.count == 0 {
+            self.tableView.backgroundView?.isHidden = false
+            self.tableView.separatorStyle = .none
+        } else {
+            self.tableView.backgroundView?.isHidden = true
+            self.tableView.separatorStyle = .singleLine
+        }
+        
         return todoList.count
     }
     

--- a/Application/To-Do/Controller/TodoViewController.swift
+++ b/Application/To-Do/Controller/TodoViewController.swift
@@ -165,10 +165,18 @@ class TodoViewController: UITableViewController {
         searchController.searchResultsUpdater = self
         searchController.searchBar.autocapitalizationType = .none
         searchController.searchBar.delegate = self
+        searchController.view.backgroundColor = .white
     }
     
     fileprivate func setupEmptyState() {
-        let emptyBackgroundView = EmptyState()
+        
+        let image = UIImage(systemName: "note.text")!
+        let heading = "No tasks added"
+        let subheading = """
+         You can create a new task with ease.
+         Tap the '+' button on top!
+         """
+        let emptyBackgroundView = EmptyState(image: image, heading: heading, subheading: subheading)
         tableView.backgroundView = emptyBackgroundView
         tableView.setNeedsLayout()
         tableView.layoutIfNeeded()

--- a/Application/To-Do/Controller/TodoViewController.swift
+++ b/Application/To-Do/Controller/TodoViewController.swift
@@ -50,7 +50,7 @@ class TodoViewController: UITableViewController {
         super.viewDidLoad()
         
         showOnboardingIfNeeded()
-        
+        setupEmptyState()
         /// Core data setup and population
         loadData()
     }
@@ -167,12 +167,28 @@ class TodoViewController: UITableViewController {
         searchController.searchBar.delegate = self
     }
     
+    fileprivate func setupEmptyState() {
+        let emptyBackgroundView = EmptyState()
+        tableView.backgroundView = emptyBackgroundView
+        tableView.setNeedsLayout()
+        tableView.layoutIfNeeded()
+    }
+    
     //MARK:  ------ Tableview Datasource methods ------
     // Reference: https://developer.apple.com/documentation/uikit/uitableviewdatasource
     
     /// function to determine `Number of rows` in tableview
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        self.sortButton.isEnabled = self.todoList.count > 0 
+        self.sortButton.isEnabled = self.todoList.count > 0
+        
+        if todoList.count == 0 {
+            tableView.separatorStyle = .none
+            tableView.backgroundView?.isHidden = false
+        } else {
+            tableView.separatorStyle = .singleLine
+            tableView.backgroundView?.isHidden = true
+        }
+        
         return todoList.count
     }
     

--- a/Application/To-Do/Helpers/EmptyState.swift
+++ b/Application/To-Do/Helpers/EmptyState.swift
@@ -14,7 +14,6 @@ class EmptyState: UIView {
     
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(systemName: "note.text")
         imageView.tintColor = .black
         imageView.contentMode = .scaleAspectFit
         
@@ -24,7 +23,6 @@ class EmptyState: UIView {
     private lazy var headingLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.boldSystemFont(ofSize: 18.0)
-        label.text = "No task added"
         label.textColor = .black
         label.numberOfLines = 0
         label.textAlignment = .center
@@ -35,7 +33,6 @@ class EmptyState: UIView {
     private lazy var subheadingLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 15.0, weight: .medium)
-        label.text = "You can create a new task with ease! \n Tap the '+' button on top."
         label.textColor = .darkGray
         label.textAlignment = .center
         
@@ -44,8 +41,12 @@ class EmptyState: UIView {
         return label
     }()
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(image: UIImage, heading: String, subheading: String) {
+        super.init(frame: .zero)
+        
+        self.imageView.image = image
+        self.headingLabel.text = heading
+        self.subheadingLabel.text = subheading
         
         let stackViews = UIStackView(arrangedSubviews: [imageView, headingLabel, subheadingLabel])
         stackViews.axis = .vertical

--- a/Application/To-Do/Helpers/EmptyState.swift
+++ b/Application/To-Do/Helpers/EmptyState.swift
@@ -1,0 +1,65 @@
+//
+//  EmptyState.swift
+//  To-Do
+//
+//  Created by Bayu Kurniawan on 10/10/20.
+//  Copyright © 2020 Aaryan Kothari. All rights reserved.
+//
+
+import UIKit
+
+class EmptyState: UIView {
+    
+    /// Properties
+    
+    private lazy var imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "note.text")
+        imageView.tintColor = .black
+        imageView.contentMode = .scaleAspectFit
+        
+        return imageView
+    }()
+    
+    private lazy var headingLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.boldSystemFont(ofSize: 18.0)
+        label.text = "No task added"
+        label.textColor = .black
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    private lazy var subheadingLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 15.0, weight: .medium)
+        label.text = "You can create a new task with ease! \n Tap the '+' button on top."
+        label.textColor = .darkGray
+        label.textAlignment = .center
+        
+        label.numberOfLines = 2
+        
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        let stackViews = UIStackView(arrangedSubviews: [imageView, headingLabel, subheadingLabel])
+        stackViews.axis = .vertical
+        stackViews.spacing = 10.0
+        
+        addSubview(stackViews)
+        stackViews.translatesAutoresizingMaskIntoConstraints = false
+        stackViews.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 0.30).isActive = true
+        stackViews.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 1.0).isActive = true
+        stackViews.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+        stackViews.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}


### PR DESCRIPTION
### Description
Customize empty state message easily

Fixes issue #65

### Type of Change:

### a. Tasks empty state view

![IMG](https://camo.githubusercontent.com/f3323a473acc758699dd4b68138659d7e35f209c/68747470733a2f2f692e6962622e636f2f6632787358545a2f53696d756c61746f722d53637265656e2d53686f742d692d50686f6e652d31312d323032302d31302d31302d61742d31372d32362d35382e706e67)

### b. Tasks non-empty state view

![IMG](https://camo.githubusercontent.com/dedda2f1e37ee28ba10b0bf383658a5abdcde7a6/68747470733a2f2f692e6962622e636f2f6437434e4d59562f53696d756c61746f722d53637265656e2d53686f742d692d50686f6e652d31312d323032302d31302d31302d61742d31372d33322d30352e706e67)

### c. Search result empty state view

![IMG](https://i.ibb.co/FHncNVq/Simulator-Screen-Shot-i-Phone-11-2020-10-10-at-20-41-59.png)

### d. Search result non-empty state view

![IMG](https://i.ibb.co/kcq5xLq/Simulator-Screen-Shot-i-Phone-11-2020-10-10-at-20-42-05.png)



- Code
- Quality Assurance
- User Interface
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)


### How Has This Been Tested?
Showing empty state message if there is no data (task)


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
